### PR TITLE
Add Docker config for Coolify deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
-.react-router
-build
 node_modules
-README.md
+.git
+.tanstack
+.output
+dist
+build
+*.md
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,29 @@
-FROM oven/bun:1 AS base
-WORKDIR /usr/src/app
+FROM node:22-alpine AS base
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
 
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json bun.lock* .npmrc* /temp/dev/
-RUN cd /temp/dev && bun install --frozen-lockfile
+FROM base AS deps
+COPY package.json package-lock.json ./
+RUN npm ci
 
-RUN mkdir -p /temp/prod
-COPY package.json bun.lock* .npmrc* /temp/prod/
-RUN cd /temp/prod && bun install --frozen-lockfile --production
-
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN npm run build
 
+FROM base AS runner
 ENV NODE_ENV=production
-RUN bun run build
+WORKDIR /app
 
-FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/dist ./dist
-COPY --from=prerelease /usr/src/app/public ./public
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 appuser
 
-USER bun
-EXPOSE 3000/tcp
+COPY --from=builder /app/.output ./.output
+COPY --from=builder /app/public ./public
+
+USER appuser
+EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["bun", "run", "dist/server/index.mjs"]
+CMD ["node", ".output/server/index.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  website:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped


### PR DESCRIPTION
- Rewrite Dockerfile to use Node.js instead of Bun (matches npm-based project)
- Fix output path from dist/ to .output/ (TanStack Start convention)
- Add docker-compose.yml for Coolify deployment
- Update .dockerignore for cleaner builds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk deployment/config-only change; main risk is runtime/build differences from switching the container base from Bun to Node and changing the build output path.
> 
> **Overview**
> Updates containerization to match the npm/Node toolchain by replacing the Bun-based `Dockerfile` with a multi-stage Node 22 Alpine build (`npm ci` + `npm run build`) and running the app from TanStack Start’s `.output/server/index.mjs`.
> 
> Adds a simple `docker-compose.yml` for production-style deployment and expands `.dockerignore` to exclude git/dev/build artifacts and env files for smaller, cleaner image builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6850ebc5e358109074e72903165ef6ab057ce37a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->